### PR TITLE
Compatibility ggplot2 4.0.0

### DIFF
--- a/tests/testthat/test_kmeans_viz.R
+++ b/tests/testthat/test_kmeans_viz.R
@@ -2,10 +2,10 @@ context("kmeans_viz")
 
 
 test_that("plot_kmeans() returns a ggplot2 object", {
-  expect_equal(
-    class(plot_kmeans(mtcars, mpg, wt, group = am)),
-    c("gg", "ggplot")
-  )
+  p <- plot_kmeans(mtcars, mpg, wt, group = am)
+  # "ggplot" is for ggplot2 3.5.2 and lower
+  # "ggplot2::ggplot" is for ggplot2 4.0.0 and above
+  expect_true(inherits(p, c("ggplot", "ggplot2::ggplot")))
 })
 
 test_that("plot_kmeans() returns error when no group is passed", {


### PR DESCRIPTION
Hi Max and team,

(apologies for the impersonal tone of this message, I've been sending similar messages around a lot!)
We've been preparing a new major release for ggplot2 and found an issue during a reverse dependency check.
The issue is described in https://github.com/tidyverse/ggplot2/issues/6498, where you're welcome to raise discussion.
The issue isn't with your packaged code, but with the particular expection changed by this PR.

You can test your code with the development version of ggplot2 by installing it as follows:

```r
# install.packages("pak")
pak::pak("tidyverse/ggplot2")
```

We aim to release the new ggplot2 version in about 2 weeks, and hope you can submit a fix to CRAN around that time. Hopefully this will inform you in a timely manner.

Best wishes,
Teun